### PR TITLE
feat: Impl trait in return position.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 edition = "2021"
 license = "MIT"
 description = "Teach your code to use magic"
+rust-version = "1.75"
 
 [dependencies]
 

--- a/src/function_impl.rs
+++ b/src/function_impl.rs
@@ -1,7 +1,3 @@
-use std::{future::Future, pin::Pin};
-
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-
 macro_rules! define_handler_for_tuple ({ $($param:ident)* } => {
 #[allow(non_snake_case, unused_mut, unused_variables)]
 impl<T, Func, Future, State, Output, $($param,)*>
@@ -19,9 +15,8 @@ where
 {
     type Response = T;
     type Error = Box<dyn std::error::Error>;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn invoke(&self, input: impl Into<T>, state: State) -> Self::Future {
+    fn invoke(&self, input: impl Into<T>, state: State) -> impl std::future::Future<Output = Result<Self::Response, Self::Error>> {
         let handler = self.clone();
         let input = input.into();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,11 +94,13 @@ pub trait Handler<T, Args, State>: Clone {
     type Response: Into<T>;
     /// The error type that the handler will return.
     type Error;
-    /// The future type that the handler will return.
-    type Future: Future<Output = Result<Self::Response, Self::Error>>;
 
     /// Invoke the handler with the given input value and state context.
-    fn invoke(&self, frame: impl Into<T>, state: State) -> Self::Future;
+    fn invoke(
+        &self,
+        into_topic: impl Into<T>,
+        state: State,
+    ) -> impl Future<Output = Result<Self::Response, Self::Error>>;
 }
 
 pub use extractors::State;


### PR DESCRIPTION
Following in [axum's][axum] footsteps, this commit drops the generic associated `Self::Future` type in preference of `impl Trait` as implemented in [Rust 1.83][rust-183].

[axum]: https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0
[rust-183]: https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html